### PR TITLE
Update the version of feedparser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup_requires = [
 install_requires = [
     'click~=6.0,>=6.7',
     'feedparser>=6.0.8',
-    #    'feedparser~=5.0,>=5.2.1',
     'requests~=2.0,>=2.18.4',
     'six~=1.0,>=1.11.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
-
 """A Python wrapper for the bioRxiv API."""
 
 from __future__ import absolute_import, division, print_function
 
 from setuptools import find_packages, setup
-
 
 url = 'https://github.com/jacquerie/biorxiv-cli'
 
@@ -17,7 +15,8 @@ setup_requires = [
 
 install_requires = [
     'click~=6.0,>=6.7',
-    'feedparser~=5.0,>=5.2.1',
+    'feedparser>=6.0.8',
+    #    'feedparser~=5.0,>=5.2.1',
     'requests~=2.0,>=2.18.4',
     'six~=1.0,>=1.11.0',
 ]


### PR DESCRIPTION
The 5.2.1 version of feedparser doesn't work in the latest versions of Python 3